### PR TITLE
No Image - Update New Deployment instructions for clarity

### DIFF
--- a/docs/getting-started/creating-a-new-deployment.mdx
+++ b/docs/getting-started/creating-a-new-deployment.mdx
@@ -23,16 +23,16 @@ A **deployment template** contains the source files for an application deploymen
 
 The PSAppDeployToolkit module can create a new deployment from PSADT's internal templates.
 
-To create a new deployment using the PSADT v4 native deployment template, run:
-
-```powershell
-New-ADTTemplate -Destination C:\Temp\MyAppDeployment -Name "MyAppDeployment"
-```
-
 To create a new deployment using the PSADT v3 compatible template, run:
 
 ```powershell
-New-ADTTemplate -Destination C:\Temp\MyAppDeployment -Name "MyOldAppDeployment" -Version 3
+New-ADTTemplate -Destination C:\Temp -Name "PSAppDeployToolkitv3" -Version 3
+```
+
+To create a new deployment using the PSADT v4 native deployment template, run:
+
+```powershell
+New-ADTTemplate -Destination C:\Temp -Name "PSAppDeployToolkitv4"
 ```
 
 

--- a/versioned_docs/version-4.0.0/getting-started/creating-a-new-deployment.mdx
+++ b/versioned_docs/version-4.0.0/getting-started/creating-a-new-deployment.mdx
@@ -26,13 +26,13 @@ The PSAppDeployToolkit module can create a new deployment from PSADT's internal 
 To create a new deployment using the PSADT v3 compatible template, run:
 
 ```powershell
-New-ADTTemplate -Destination C:\Temp\MyAppDeployment -Name "MyOldAppDeployment" -Version 3
+New-ADTTemplate -Destination C:\Temp -Name "PSAppDeployToolkitv3" -Version 3
 ```
 
 To create a new deployment using the PSADT v4 native deployment template, run:
 
 ```powershell
-New-ADTTemplate -Destination C:\Temp\MyAppDeployment -Name "MyAppDeployment"
+New-ADTTemplate -Destination C:\Temp -Name "PSAppDeployToolkitv4"
 ```
 
 ## Using the downloadable templates


### PR DESCRIPTION
- Corrected the examples for creating new deployments using PSADT v3 and v4 templates in both `creating-a-new-deployment.mdx` files.
- Updated the destination paths and names to reflect accurate usage for better clarity.

These changes enhance the documentation for users setting up new deployments.