### PR TITLE
Update Exit Codes Reference page

### DIFF
--- a/docs/reference/exit-codes.mdx
+++ b/docs/reference/exit-codes.mdx
@@ -21,4 +21,4 @@ PSAppDeployToolkit uses pre-defined exit codes to indicate whether a deployment 
 | 60010         | `Invoke-AppDeployToolkit.exe` failed before PowerShell.exe process could be launched.                                                                                        |
 | 60011         | `Invoke-AppDeployToolkit.exe` failed to execute the PowerShell.exe process.                                                                                                  |
 | 69000 - 69999 | Recommended for user customized exit codes in `Invoke-AppDeployToolkit.ps1`.                                                                                                 |
-| 70000 - 79999 | Recommended for user customized exit codes in `Invoke-AppDeployToolkit.ps1`.                                                                                                 |
+| 70000 - 79999 | Recommended for user customized exit codes in PSAppDeployToolkit.Extensions module..                                                                                                 |


### PR DESCRIPTION
#223
Updating Exit Codes page

Updated the 60008 exit code description to better reflect the area it pertains to.

Remove deprecated exit codes from exit-codes documentation as there are no longer any references to them.
- 60003-60007
- 60009
- 60012-60013

Remove deprecated exit code 60002 from exit-codes documentation
- Making an assumption here that this code is no longer used. The only reference is in the `Invoke-ADTRegSvr32.ps1` when checking if the error code return from `Start-ADTProcess` is 60002.
    - https://github.com/PSAppDeployToolkit/PSAppDeployToolkit/blob/101c1898a94d9faedd52a9b16a87b25afc98c423/src/PSAppDeployToolkit/Public/Invoke-ADTRegSvr32.ps1#L155
- But looking at `Start-ADTProcess`, it doesn't appear to throw that error any longer?