### PR TITLE
Revert "Fix YAML code injection vulnerability in gray-matter patch"

### DIFF
--- a/patches/gray-matter@4.0.3.patch
+++ b/patches/gray-matter@4.0.3.patch
@@ -8,8 +8,8 @@ index 38f993db06cf364191ac635a6590c2d29303297d..1dfec8d9527653ad9ccfaacfa5973224
  engines.yaml = {
 -  parse: yaml.safeLoad.bind(yaml),
 -  stringify: yaml.safeDump.bind(yaml)
-+  parse: yaml.safeLoad.bind(yaml),
-+  stringify: yaml.safeDump.bind(yaml)
++  parse: yaml.load.bind(yaml),
++  stringify: yaml.dump.bind(yaml)
  };
  
  /**


### PR DESCRIPTION
Reverts PSAppDeployToolkit/website#399. This was a false alert from CodeQL.