### PR TITLE
Various documentation fixes

### DIFF
--- a/docs/deployment-concepts/invoke-appdeploytoolkit.mdx
+++ b/docs/deployment-concepts/invoke-appdeploytoolkit.mdx
@@ -42,18 +42,18 @@ These are the first thing to edit in your deployment script and are stored withi
 | `AppProcessesToClose` | `@(@{ Name = 'winword'; Description = 'Microsoft Word' })` | **New in v4.1**. Processes that should be closed before install / uninstall / repair. |
 | `RequireAdmin`        | `$true`                                                    | **New in v4.1**. Whether the script requires administrative privileges                |
 
-:::warning Breaking Changes in v4.1
+:::warning[Breaking Changes in v4.1]
 If you are upgrading from v4.0 or earlier, you must move any `RequireAdmin` setting from your config file to the session object in your deployment script, and use `AppProcessesToClose` instead of specifying the processes directly on the `-CloseProcesses` parameter of `Show-ADTInstallationWelcome`.
 :::
 
-:::info New in v4.1: RequireAdmin
+:::info[New in v4.1: RequireAdmin]
 PSADT v4.1 contains a new variable `RequireAdmin` that allows you to check for administrative rights on a per-application basis without needing to modify the PSADT configuration file.
 
 - `RequireAdmin = $true`, will fail the deployment if admin rights are not available.
 - `RequireAdmin = $false`, will run in the users context without requiring administrative rights.
 :::
 
-:::info New in v4.1: AppProcessesToClose
+:::info[New in v4.1: AppProcessesToClose]
 PSADT v4.1 contains a new variable `AppProcessesToClose` that allows you to specify processes to be closed before the installation, uninstallation, or repair phases. This replaces the previous method of using the -CloseApps parameter on `Show-InstallationWelcome`
 
 - `AppProcessesToClose = <populated>`, will automatically close the specified processes before proceeding with the deployment.

--- a/docs/deployment-concepts/invoke-appdeploytoolkit.mdx
+++ b/docs/deployment-concepts/invoke-appdeploytoolkit.mdx
@@ -51,12 +51,12 @@ If you are upgrading from v4.0 or earlier, you must move any `RequireAdmin` sett
 :::
 
 :::info[New in v4.1: RequireAdmin]
-PSADT v4.1 contains a new variable `RequireAdmin` that allows you to check for administrative rights on a per-application basis without needing to modify the PSADT configuration file.
+PSADT v4.1 contains a new variable `RequireAdmin` that allows you to check for administrative privileges on a per-application basis without needing to modify the PSADT configuration file.
 
-- `RequireAdmin = $true`, will fail the deployment if admin rights are not available.
-- `RequireAdmin = $false`, will not check for admin rights.
+- `RequireAdmin = $true`, will fail the deployment if administrative privileges are not available.
+- `RequireAdmin = $false`, will not check for administrative privileges.
 
-Note that `Invoke-AppDeployToolkit.exe` no longer checks this value to figure out if it needs to relaunch itself elevated. If your deployment requires admin rights, you must ensure that the launcher is run elevated.
+Note that `Invoke-AppDeployToolkit.exe` no longer checks this value to figure out if it needs to relaunch itself elevated. If your deployment requires administrative privileges, you must ensure that the launcher is run elevated.
 :::
 
 :::info[New in v4.1: AppProcessesToClose]

--- a/docs/deployment-concepts/invoke-appdeploytoolkit.mdx
+++ b/docs/deployment-concepts/invoke-appdeploytoolkit.mdx
@@ -42,6 +42,10 @@ These are the first thing to edit in your deployment script and are stored withi
 | `AppProcessesToClose` | `@(@{ Name = 'winword'; Description = 'Microsoft Word' })` | **New in v4.1**. Processes that should be closed before install / uninstall / repair. |
 | `RequireAdmin`        | `$true`                                                    | **New in v4.1**. Whether the script requires administrative privileges                |
 
+:::warning[PSAppDeployToolkit variables]
+If trying to use a PSAppDeployToolkit variables such as $envProgramFiles in this section, it will not work because the module has typically not been imported and initialized this early on in the script.
+:::
+
 :::warning[Breaking Changes in v4.1]
 If you are upgrading from v4.0 or earlier, you must move any `RequireAdmin` setting from your config file to the session object in your deployment script, and use `AppProcessesToClose` instead of specifying the processes directly on the `-CloseProcesses` parameter of `Show-ADTInstallationWelcome`.
 :::

--- a/docs/deployment-concepts/invoke-appdeploytoolkit.mdx
+++ b/docs/deployment-concepts/invoke-appdeploytoolkit.mdx
@@ -56,7 +56,7 @@ PSADT v4.1 contains a new variable `RequireAdmin` that allows you to check for a
 - `RequireAdmin = $true`, will fail the deployment if admin rights are not available.
 - `RequireAdmin = $false`, will not check for admin rights.
 
-Note that Invoke-AppDeployToolkit.exe no longer checks this value to figure out if it needs to relaunch itself elevated. If your deployment requires admin rights, you must ensure that the launcher is run elevated.
+Note that `Invoke-AppDeployToolkit.exe` no longer checks this value to figure out if it needs to relaunch itself elevated. If your deployment requires admin rights, you must ensure that the launcher is run elevated.
 :::
 
 :::info[New in v4.1: AppProcessesToClose]

--- a/docs/deployment-concepts/invoke-appdeploytoolkit.mdx
+++ b/docs/deployment-concepts/invoke-appdeploytoolkit.mdx
@@ -54,7 +54,9 @@ If you are upgrading from v4.0 or earlier, you must move any `RequireAdmin` sett
 PSADT v4.1 contains a new variable `RequireAdmin` that allows you to check for administrative rights on a per-application basis without needing to modify the PSADT configuration file.
 
 - `RequireAdmin = $true`, will fail the deployment if admin rights are not available.
-- `RequireAdmin = $false`, will run in the users context without requiring administrative rights.
+- `RequireAdmin = $false`, will not check for admin rights.
+
+Note that Invoke-AppDeployToolkit.exe no longer checks this value to figure out if it needs to relaunch itself elevated. If your deployment requires admin rights, you must ensure that the launcher is run elevated.
 :::
 
 :::info[New in v4.1: AppProcessesToClose]

--- a/docs/getting-started/faq.mdx
+++ b/docs/getting-started/faq.mdx
@@ -111,7 +111,7 @@ tags:
 <details>
   <summary>Can I use PSAppDeployToolkit to install user-context apps?</summary>
 
-  Yes. Ensure `RequireAdmin = $false` is configured within the `$adtSession` properties in Invoke-AppDeployToolkit.ps1. As of 4.1, the `RequireAdmin` is no longer to be found in Config.psd1.
+  Yes. Ensure `RequireAdmin = $false` is configured within the `$adtSession` properties in `Invoke-AppDeployToolkit.ps1`. As of 4.1, the `RequireAdmin` is no longer to be found in Config.psd1.
 </details>
 
 <details>

--- a/docs/getting-started/release-notes.mdx
+++ b/docs/getting-started/release-notes.mdx
@@ -139,7 +139,7 @@ This release strengthens Windows Installer (.msi) and Patch (.msp) deployment re
 - Set default parameter set for `Start-ADTMspProcess`.
 - Changed `Start-ADTMsiProcessAsUser` to ensure it uses a user-writeable log location.
 - Fixed bad parameter set grouping for `Start-ADTProcess` family of functions.
-- Fixed issue where `Set-ADTItemPermissions` always needed admin rights to change inheritance options
+- Fixed issue where `Set-ADTItemPermissions` always needed administrative privileges to change inheritance options
 - Fixed issue where `Set-ADTActiveSetup` `-PurgeActiveSetupKey` would only clean up keys for the active user.
 - Fixed `StdOut`/`StdErr`/`Interleaved` printing within `Start-ADTProcess`.
 - Changed `Start-ADTProcessAsUser` to allow operating with any valid user, such as disconnected RDP users.

--- a/docs/getting-started/upgrade-guidance-4x-to-v41.mdx
+++ b/docs/getting-started/upgrade-guidance-4x-to-v41.mdx
@@ -20,7 +20,7 @@ tags:
 - `OOBEDetection` and `SessionDetection` are no longer set in Config.psd1. They can be set per-deployment by adding the `NoOOBEDetection` and `NoSessionDetection` options to the session properties if required.
 - `AppProcessesToClose` is a new session property that allows you to define processes to close during Install/Uninstall/Repair in one place instead of specifying the processes directly on the `-CloseProcesses` parameter of `Show-ADTInstallationWelcome`.
 - `RequireAdmin` is no longer set in Config.psd1. It must be set per-deployment in the session properties.
-- Invoke-AppDeployToolkit.exe no longer requests elevation if RequireAdmin is set; you must elevate this yourself.
+- `Invoke-AppDeployToolkit.exe` no longer requests elevation if RequireAdmin is set; you must elevate this yourself.
 - Several config options have been removed or had their default values changed. See below for details.
 - Deprecated functions and parameters are scheduled for removal in 4.2.0. Update your scripts accordingly.
 

--- a/docs/getting-started/upgrade-guidance-4x-to-v41.mdx
+++ b/docs/getting-started/upgrade-guidance-4x-to-v41.mdx
@@ -20,6 +20,7 @@ tags:
 - `OOBEDetection` and `SessionDetection` are no longer set in Config.psd1. They can be set per-deployment by adding the `NoOOBEDetection` and `NoSessionDetection` options to the session properties if required.
 - `AppProcessesToClose` is a new session property that allows you to define processes to close during Install/Uninstall/Repair in one place instead of specifying the processes directly on the `-CloseProcesses` parameter of `Show-ADTInstallationWelcome`.
 - `RequireAdmin` is no longer set in Config.psd1. It must be set per-deployment in the session properties.
+- Invoke-AppDeployToolkit.exe no longer requests elevation if RequireAdmin is set; you must elevate this yourself.
 - Several config options have been removed or had their default values changed. See below for details.
 - Deprecated functions and parameters are scheduled for removal in 4.2.0. Update your scripts accordingly.
 

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -32,8 +32,7 @@ PSAppDeployToolkit is open-source software and provided free for anyone to use. 
 - [Functions Reference](./category/functions)
   - A reference for all the functions provided by PSAppDeployToolkit, including parameters and examples of how to use them.
 
-:::info Enterpise Support
-
+:::info[Enterprise Support]
 We recognize that some enterprises face adoption challenges due to audit requirements for vendor support. Patch My PC are stewards of the PSADT Project and, as experts in open-source deployment, are uniquely positioned to offer both deep technical knowledge and enterprise-level support - allowing customers to fully benefit from open-source tools without compromise. [Learn more about Patch My PC's support for PSADT](https://patchmypc.com/support/psappdeploytoolkit-support).
 :::
 

--- a/docs/reference/config-settings.mdx
+++ b/docs/reference/config-settings.mdx
@@ -23,7 +23,7 @@ PSAppDeployToolkit provides comprehensive configuration management through multi
 | `Assets.Banner`   | Specify filename or Base64 string of the banner (Classic-only). |
 | `Assets.Logo`     | Specify filename or Base64 string of the logo.                  |
 | `Assets.LogoDark` | Specify filename or Base64 string of the logo (for dark mode).  |
-| `TaskbarIcon`     | Specify optional filename or Base64 string of the tray icon.    |
+| `Assets.TaskbarIcon`     | Specify optional filename or Base64 string of the tray icon.    |
 
 :::info[Dark Mode Support]
 `Assets.LogoDark` enables different logos for light and dark themes in the modern Fluent UI framework.

--- a/docs/reference/config-settings.mdx
+++ b/docs/reference/config-settings.mdx
@@ -43,15 +43,15 @@ PSAppDeployToolkit provides comprehensive configuration management through multi
 | `Toolkit.LogMaxHistory`             | Sets the maximum history for logs.                                                                                                                                                               |
 | `Toolkit.LogMaxSize`                | Defines the maximum size for logs.                                                                                                                                                               |
 | `Toolkit.LogPath`                   | Specifies the path where logs are stored.                                                                                                                                                        |
-| `Toolkit.LogPathNoAdminRights`      | Specifies the log path when no admin rights are available.                                                                                                                                       |
+| `Toolkit.LogPathNoAdminRights`      | Specifies the log path when no administrative privileges are available.                                                                                                                                       |
 | `Toolkit.LogStyle`                  | Sets the style for logging.                                                                                                                                                                      |
 | `Toolkit.LogToHierarchy`            | Log to a hierarchical structure of AppVendor\AppName\AppVersion.                                                                                                                                 |
 | `Toolkit.LogToSubfolder`            | Log to a subfolder based on InstallName.                                                                                                                                                         |
 | `Toolkit.LogWriteToHost`            | Determines if logs should be written to the host.                                                                                                                                                |
 | `Toolkit.RegPath`                   | Specifies the registry path for the toolkit.                                                                                                                                                     |
-| `Toolkit.RegPathNoAdminRights`      | Specifies the registry path when no admin rights are available.                                                                                                                                  |
+| `Toolkit.RegPathNoAdminRights`      | Specifies the registry path when no administrative privileges are available.                                                                                                                                  |
 | `Toolkit.TempPath`                  | Specifies the temporary path for the toolkit.                                                                                                                                                    |
-| `Toolkit.TempPathNoAdminRights`     | Specifies the temporary path when no admin rights are available.                                                                                                                                 |
+| `Toolkit.TempPathNoAdminRights`     | Specifies the temporary path when no administrative privileges are available.                                                                                                                                 |
 
 
 #### Windows Installer (MSI) Execution Settings
@@ -61,7 +61,7 @@ PSAppDeployToolkit provides comprehensive configuration management through multi
 | `MSI.InstallParams`        | Defines the installation parameters for MSI. **Default changed to `/qn REBOOT=ReallySuppress`**                         |
 | `MSI.LoggingOptions`       | Specifies the logging options for MSI.                                                                                  |
 | `MSI.LogPath`              | Specifies the log path for MSI. **Now uses Toolkit.LogPath when empty**                                                 |
-| `MSI.LogPathNoAdminRights` | Specifies the log path for MSI when no admin rights are available. **Now uses Toolkit.LogPathNoAdminRights when empty** |
+| `MSI.LogPathNoAdminRights` | Specifies the log path for MSI when no administrative privileges are available. **Now uses Toolkit.LogPathNoAdminRights when empty** |
 | `MSI.MutexWaitTime`        | Sets the mutex wait time for MSI.                                                                                       |
 | `MSI.SilentParams`         | Defines the silent parameters for MSI.                                                                                  |
 | `MSI.UninstallParams`      | Defines the uninstall parameters for MSI.                                                                               |

--- a/docs/reference/config-settings.mdx
+++ b/docs/reference/config-settings.mdx
@@ -14,23 +14,16 @@ tags:
 
 PSAppDeployToolkit provides comprehensive configuration management through multiple layers: Group Policy (highest precedence), local configuration files, and built-in defaults.
 
-In PSADT v4.1, we've introduced **Group Policy ADMX templates** for centralized enterprise configuration management. Group Policy settings override local configuration files.
-
-**Configuration Precedence (Highest to Lowest):**
-
-1. **Group Policy Settings** (via ADMX templates)
-2. **Local Config.psd1** files
-3. **Built-in Defaults**
-
 ### Settings
 
 #### Assets
 
-| Setting           | Description                       |
-| :---------------- | :-------------------------------- |
-| `Assets.Banner`   | Specifies the banner asset.       |
-| `Assets.Logo`     | Specifies the logo asset.         |
-| `Assets.LogoDark` | Path to the dark mode logo image. |
+| Setting           | Description                                                     |
+| :---------------- | :-------------------------------------------------------------- |
+| `Assets.Banner`   | Specify filename or Base64 string of the banner (Classic-only). |
+| `Assets.Logo`     | Specify filename or Base64 string of the logo.                  |
+| `Assets.LogoDark` | Specify filename or Base64 string of the logo (for dark mode).  |
+| `TaskbarIcon`     | Specify optional filename or Base64 string of the tray icon.    |
 
 :::info[Dark Mode Support]
 `Assets.LogoDark` enables different logos for light and dark themes in the modern Fluent UI framework.
@@ -55,17 +48,11 @@ In PSADT v4.1, we've introduced **Group Policy ADMX templates** for centralized 
 | `Toolkit.LogToHierarchy`            | Log to a hierarchical structure of AppVendor\AppName\AppVersion.                                                                                                                                 |
 | `Toolkit.LogToSubfolder`            | Log to a subfolder based on InstallName.                                                                                                                                                         |
 | `Toolkit.LogWriteToHost`            | Determines if logs should be written to the host.                                                                                                                                                |
-| `Toolkit.OobeDetection`             | Detects Out-of-Box Experience (OOBE) state. If enabled, the toolkit will check if the device has completed OOBE (including User ESP phase as of 4.1) and may switch DeployMode to Silent if not. |
-| `Toolkit.ProcessDetection`          | Auto-change DeployMode if there are no processes to close.                                                                                                                                       |
 | `Toolkit.RegPath`                   | Specifies the registry path for the toolkit.                                                                                                                                                     |
 | `Toolkit.RegPathNoAdminRights`      | Specifies the registry path when no admin rights are available.                                                                                                                                  |
-| `Toolkit.SessionDetection`          | Detects user session state. If enabled, the toolkit will check for an active user session and may switch DeployMode to Silent if none is found.                                                  |
 | `Toolkit.TempPath`                  | Specifies the temporary path for the toolkit.                                                                                                                                                    |
 | `Toolkit.TempPathNoAdminRights`     | Specifies the temporary path when no admin rights are available.                                                                                                                                 |
 
-:::info[ Automatic Silent Switching]
-When `Toolkit.ProcessDetection` is enabled and no processes from `AppProcessesToClose` are running, deployments automatically switch to Silent mode for optimal user experience.
-:::
 
 #### Windows Installer (MSI) Execution Settings
 
@@ -90,10 +77,11 @@ When `Toolkit.ProcessDetection` is enabled and no processes from `AppProcessesTo
 | `UI.DeferExitCode`                | Specifies the exit code for deferred actions. **Default changed to 1602** |
 | `UI.DialogStyle`                  | Defines the appearance of dialogs.                                        |
 | `UI.FluentAccentColor`            | Specifies the accent color for Fluent UI dialogs.                         |
+| `UI.FluentAccentColorDark`        | Specifies the accent color for Fluent UI dialogs (for dark mode).         |
 | `UI.LanguageOverride`             | Overrides the language for the UI.                                        |
 | `UI.PromptToSaveTimeout`          | Controls how long the user has to respond before a prompt closes.         |
 | `UI.RestartPromptPersistInterval` | Sets the interval for restart prompt persistence.                         |
 
 :::info[Custom Branding]
-Use `UI.FluentAccentColor` to match your organization's branding in modern Fluent UI dialogs. Supports standard color names and hex values.
+Use `UI.FluentAccentColor` and `UI.FluentAccentColorDark` to match your organization's branding in modern Fluent UI dialogs. Supports standard color names and hex values.
 :::

--- a/docs/reference/config-settings.mdx
+++ b/docs/reference/config-settings.mdx
@@ -32,7 +32,7 @@ In PSADT v4.1, we've introduced **Group Policy ADMX templates** for centralized 
 | `Assets.Logo`     | Specifies the logo asset.         |
 | `Assets.LogoDark` | Path to the dark mode logo image. |
 
-:::info Dark Mode Support
+:::info[Dark Mode Support]
 `Assets.LogoDark` enables different logos for light and dark themes in the modern Fluent UI framework.
 :::
 
@@ -63,7 +63,7 @@ In PSADT v4.1, we've introduced **Group Policy ADMX templates** for centralized 
 | `Toolkit.TempPath`                  | Specifies the temporary path for the toolkit.                                                                                                                                                    |
 | `Toolkit.TempPathNoAdminRights`     | Specifies the temporary path when no admin rights are available.                                                                                                                                 |
 
-:::info Automatic Silent Switching
+:::info[ Automatic Silent Switching]
 When `Toolkit.ProcessDetection` is enabled and no processes from `AppProcessesToClose` are running, deployments automatically switch to Silent mode for optimal user experience.
 :::
 
@@ -94,6 +94,6 @@ When `Toolkit.ProcessDetection` is enabled and no processes from `AppProcessesTo
 | `UI.PromptToSaveTimeout`          | Controls how long the user has to respond before a prompt closes.         |
 | `UI.RestartPromptPersistInterval` | Sets the interval for restart prompt persistence.                         |
 
-:::info Custom Branding
+:::info[Custom Branding]
 Use `UI.FluentAccentColor` to match your organization's branding in modern Fluent UI dialogs. Supports standard color names and hex values.
 :::

--- a/docs/reference/exit-codes.mdx
+++ b/docs/reference/exit-codes.mdx
@@ -16,7 +16,7 @@ PSAppDeployToolkit uses pre-defined exit codes to indicate whether a deployment 
 
 | Exit Code     | Description                                                                                                                       |
 | :------------ | :-------------------------------------------------------------------------------------------------------------------------------- |
-| 60000 - 68999 | Reserved for built-in exit codes in _Invoke-AppDeployToolkit.ps1_, _Invoke-AppDeployToolkit.exe_, and _AppDeployToolkitMain.ps1_. |
+| 60000 - 68999 | Reserved for built-in exit codes in `Invoke-AppDeployToolkit.ps1`, `Invoke-AppDeployToolkit.exe`, and `AppDeployToolkitMain.ps1`. |
 | 60001         | An error occurred in `Invoke-AppDeployToolkit.ps1`. Check your script syntax use.                                                 |
 | 60008         | Failure when importing the module or opening a new session.                                                                       |
 | 60010         | `Invoke-AppDeployToolkit.exe` failed before PowerShell.exe process could be launched.                                             |

--- a/docs/reference/variables.mdx
+++ b/docs/reference/variables.mdx
@@ -12,7 +12,7 @@ tags:
 
 ## Variables
 
-When you open an ADTSession (automatically handled in Invoke-AppDeployToolkit.ps1), several useful variables are created. These include hardware information, system and user paths, and Active Directory domain details, among others.
+When you open an ADTSession (automatically handled in `Invoke-AppDeployToolkit.ps1`), several useful variables are created. These include hardware information, system and user paths, and Active Directory domain details, among others.
 
 These variables can also be instantiated without opening a session by calling the [Export-ADTEnvironmentTableToSessionState](../reference/functions/Export-ADTEnvironmentTableToSessionState.mdx) command.
 

--- a/docs/reference/variables.mdx
+++ b/docs/reference/variables.mdx
@@ -102,7 +102,7 @@ Variables specific to a particular deployment, such as `$appName` and `$appVersi
 | Variable                | Description                                                                                                 |
 | :---------------------- | :---------------------------------------------------------------------------------------------------------- |
 | `$envOS`                | Object that contains details about the operating system                                                     |
-| `$envOSArchitecture`    | Represents the OS architecture (e.g. 32-Bit/64-Bit)                                                         |
+| `$envOSArchitecture`    | Represents the OS architecture (e.g. X86/X64/Arm64)                                                         |
 | `$envOSName`            | Name of the operating system (e.g. Microsoft Windows 8.1 Pro)                                               |
 | `$envOSProductType`     | OS product type represented as an integer (e.g. 1/2/3)                                                      |
 | `$envOSProductTypeName` | OS product type name (e.g. Server/Domain Controller/Workstation/Unknown)                                    |

--- a/docs/usage/how-to-deploy.mdx
+++ b/docs/usage/how-to-deploy.mdx
@@ -17,20 +17,21 @@ There are two ways to launch the PSAppDeployToolkit for deployment of applicatio
 `%SystemRoot%\System32\WindowsPowerShell\v1.0\PowerShell.exe -ExecutionPolicy Bypass -NoProfile -File Invoke-AppDeployToolkit.ps1`
 - Run `Invoke-AppDeployToolkit.exe` to launch `Invoke-AppDeployToolkit.ps1` in a hidden PowerShell window.
 
-:::info
+:::info[Elevation]
+If your script uses `RequireAdmin = $true`, you will need to run it as admin; the launcher will not prompt for elevation by itself.
+:::
+
+:::info[ServiceUI]
 Additionally, as of v4.1.0:
 
 - If deploying via **Intune**, there is no longer any reqirement to use `ServiceUI.exe` workarounds to display the UI.
 - If deploying via **Configuration Manager**, the **'Allow users to view and interact with the program installation'** option is no longer required to display the UI.
 - Invoke-ServiceUI.ps1 has been removed from the toolkit as it is no longer required.
-
 :::
 
 :::warning
-
 - If you want to deploy an installer interactively, you can include ServiceUI.exe in your package and use that to trigger your installer.
 - However, this is a security risk since any file dialogs or hyperlinks can be abused by the user to gain access as local system.
-
 :::
 
 ### Available parameters

--- a/docs/usage/how-to-deploy.mdx
+++ b/docs/usage/how-to-deploy.mdx
@@ -46,15 +46,15 @@ The following parameters are accepted by `Invoke-AppDeployToolkit.ps1` and `Invo
 | `-TerminalServerMode`                                                 |                                                            | Changes to user install mode for RDS/Citrix servers.                                                                           |
 | `-DisableLogging`                                                     |                                                            | Disables logging to file.                                                                                                      |
 
-In addition, Invoke-AppDeployToolkit.exe supports the following parameters:
+In addition, `Invoke-AppDeployToolkit.exe` supports the following parameters:
 
 | Parameter | Values | Description                                                                                                  |
 | --------- | ------ | ------------------------------------------------------------------------------------------------------------ |
 | `/Debug`  |        | Launches the script in a visible window displaying live logging output on-screen.                            |
 | `/32`     |        | Launches the script using PowerShell x86. This is useful for compatibility with x86 libraries or components. |
 | `/Core`   |        | Launches the script using PowerShell Core (pwsh.exe).                                                        |
-| `-File`   | *.ps1  | Specify a custom script file to run instead of the default Invoke-AppDeployToolkit.ps1.                      |
-| `*.ps1`   |        | Specify a custom script file to run instead of the default Invoke-AppDeployToolkit.ps1.                      |
+| `-File`   | *.ps1  | Specify a custom script file to run instead of the default `Invoke-AppDeployToolkit.ps1`.                      |
+| `*.ps1`   |        | Specify a custom script file to run instead of the default `Invoke-AppDeployToolkit.ps1`.                      |
 
 ### Examples
 

--- a/versioned_docs/version-3.10.2/usage/customizing-deployments.mdx
+++ b/versioned_docs/version-3.10.2/usage/customizing-deployments.mdx
@@ -15,7 +15,7 @@ Aside from customizing the `Deploy-Application.ps1` script to deploy your applic
 
 ### AppDeployToolkitConfig.xml
 
-Configure the default UI messages, MSI parameters, log file location, whether Admin rights should be required, whether log files should be compressed, log style (CMTrace or Legacy), max log size, whether debug messages should be logged, whether log entries should be written to the console, whether toolkit should re-launch as elevated logged-on console user when in SYSTEM context, whether toolkit should fall back to SYSTEM context if failure to launch toolkit as user, and whether toolkit should attempt to launch as a non-console logged on user (e.g. user logged on via terminal services) when in SYSTEM context.
+Configure the default UI messages, MSI parameters, log file location, whether administrative privileges should be required, whether log files should be compressed, log style (CMTrace or Legacy), max log size, whether debug messages should be logged, whether log entries should be written to the console, whether toolkit should re-launch as elevated logged-on console user when in SYSTEM context, whether toolkit should fall back to SYSTEM context if failure to launch toolkit as user, and whether toolkit should attempt to launch as a non-console logged on user (e.g. user logged on via terminal services) when in SYSTEM context.
 
 ### AppDeployToolkitLogo.ico
 

--- a/versioned_docs/version-4.0.x/getting-started/faq.mdx
+++ b/versioned_docs/version-4.0.x/getting-started/faq.mdx
@@ -118,5 +118,5 @@ tags:
 <details>
   <summary>Can I use PSAppDeployToolkit to install user-context apps?</summary>
 
-  Yes. Set the `RequireAdmin` option in Config.psd1 to `$false` if the installation does not require administrative rights.
+  Yes. Set the `RequireAdmin` option in Config.psd1 to `$false` if the installation does not require administrative privileges.
 </details>

--- a/versioned_docs/version-4.0.x/reference/config-settings.mdx
+++ b/versioned_docs/version-4.0.x/reference/config-settings.mdx
@@ -43,7 +43,6 @@ tags:
 | Toolkit.SessionDetection          | Detects user session state.                                      |
 | Toolkit.TempPath                  | Specifies the temporary path for the toolkit.                    |
 | Toolkit.TempPathNoAdminRights     | Specifies the temporary path when no admin rights are available. |
-| Toolkit.UIHostProcess             | Specifies the UI host process for the toolkit.                   |
 
 ## Windows Installer (MSI) Execution Settings
 | Setting                  | Description                                                        |

--- a/versioned_docs/version-4.0.x/reference/config-settings.mdx
+++ b/versioned_docs/version-4.0.x/reference/config-settings.mdx
@@ -33,16 +33,16 @@ tags:
 | Toolkit.LogMaxHistory             | Sets the maximum history for logs.                               |
 | Toolkit.LogMaxSize                | Defines the maximum size for logs.                               |
 | Toolkit.LogPath                   | Specifies the path where logs are stored.                        |
-| Toolkit.LogPathNoAdminRights      | Specifies the log path when no admin rights are available.       |
+| Toolkit.LogPathNoAdminRights      | Specifies the log path when no administrative privileges are available.       |
 | Toolkit.LogStyle                  | Sets the style for logging.                                      |
 | Toolkit.LogWriteToHost            | Determines if logs should be written to the host.                |
 | Toolkit.OobeDetection             | Detects Out-of-Box Experience (OOBE) state.                      |
 | Toolkit.RegPath                   | Specifies the registry path for the toolkit.                     |
-| Toolkit.RegPathNoAdminRights      | Specifies the registry path when no admin rights are available.  |
-| Toolkit.RequireAdmin              | Indicates if administrative rights are required.                 |
+| Toolkit.RegPathNoAdminRights      | Specifies the registry path when no administrative privileges are available.  |
+| Toolkit.RequireAdmin              | Indicates if administrative privileges are required.                 |
 | Toolkit.SessionDetection          | Detects user session state.                                      |
 | Toolkit.TempPath                  | Specifies the temporary path for the toolkit.                    |
-| Toolkit.TempPathNoAdminRights     | Specifies the temporary path when no admin rights are available. |
+| Toolkit.TempPathNoAdminRights     | Specifies the temporary path when no administrative privileges are available. |
 
 ## Windows Installer (MSI) Execution Settings
 | Setting                  | Description                                                        |
@@ -50,7 +50,7 @@ tags:
 | MSI.InstallParams        | Defines the installation parameters for MSI.                       |
 | MSI.LoggingOptions       | Specifies the logging options for MSI.                             |
 | MSI.LogPath              | Specifies the log path for MSI.                                    |
-| MSI.LogPathNoAdminRights | Specifies the log path for MSI when no admin rights are available. |
+| MSI.LogPathNoAdminRights | Specifies the log path for MSI when no administrative privileges are available. |
 | MSI.MutexWaitTime        | Sets the mutex wait time for MSI.                                  |
 | MSI.SilentParams         | Defines the silent parameters for MSI.                             |
 | MSI.UninstallParams      | Defines the uninstall parameters for MSI.                          |

--- a/versioned_docs/version-4.0.x/reference/exit-codes.mdx
+++ b/versioned_docs/version-4.0.x/reference/exit-codes.mdx
@@ -16,7 +16,7 @@ PSAppDeployToolkit uses pre-defined exit codes to indicate whether a deployment 
 
 | Exit Code     | Description                                                                                                                                                                  |
 |:--------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| 60000 - 68999 | Reserved for built-in exit codes in _Invoke-AppDeployToolkit.ps1_, _Invoke-AppDeployToolkit.exe_, and _AppDeployToolkitMain.ps1_.                                            |
+| 60000 - 68999 | Reserved for built-in exit codes in `Invoke-AppDeployToolkit.ps1`, `Invoke-AppDeployToolkit.exe`, and `AppDeployToolkitMain.ps1`.                                            |
 | 60001         | An error occurred in `Invoke-AppDeployToolkit.ps1`. Check your script syntax use.                                                                                            |
 | 60002         | Error when running `Start-ADTProcess` function.                                                                                                                              |
 | 60003         | Administrator privileges required for `Start-ADTProcessAsUser` function.                                                                                                     |

--- a/versioned_docs/version-4.0.x/reference/variables.mdx
+++ b/versioned_docs/version-4.0.x/reference/variables.mdx
@@ -102,7 +102,7 @@ Variables specific to a particular deployment, such as `$appName` and `$appVersi
 | Variable                | Description                                                                                                 |
 |:------------------------|:------------------------------------------------------------------------------------------------------------|
 | `$envOS`                | Object that contains details about the operating system                                                     |
-| `$envOSArchitecture`    | Represents the OS architecture (e.g. 32-Bit/64-Bit)                                                         |
+| `$envOSArchitecture`    | Represents the OS architecture (e.g. i386/AMD64/ARM64)                                                         |
 | `$envOSName`            | Name of the operating system (e.g. Microsoft Windows 8.1 Pro)                                               |
 | `$envOSProductType`     | OS product type represented as an integer (e.g. 1/2/3)                                                      |
 | `$envOSProductTypeName` | OS product type name (e.g. Server/Domain Controller/Workstation/Unknown)                                    |

--- a/versioned_docs/version-4.0.x/reference/variables.mdx
+++ b/versioned_docs/version-4.0.x/reference/variables.mdx
@@ -12,7 +12,7 @@ tags:
 
 # Variables
 
-When you open an ADTSession (automatically handled in Invoke-AppDeployToolkit.ps1), several useful variables are created. These include hardware information, system and user paths, and Active Directory domain details, among others.
+When you open an ADTSession (automatically handled in `Invoke-AppDeployToolkit.ps1`), several useful variables are created. These include hardware information, system and user paths, and Active Directory domain details, among others.
 
 These variables can also be instantiated without opening a session by calling the [Export-ADTEnvironmentTableToSessionState](../reference/functions/Export-ADTEnvironmentTableToSessionState.mdx) command.
 

--- a/versioned_docs/version-4.0.x/usage/customizing-deployments.mdx
+++ b/versioned_docs/version-4.0.x/usage/customizing-deployments.mdx
@@ -17,7 +17,7 @@ Aside from customizing the `Invoke-AppDeployToolkit.ps1` script, no configuratio
 
 Use config.psd1 to configure items such as:
 
-- Are Admin rights required
+- Are administrative privileges required
 - MSI parameters
 - Log settings
 

--- a/versioned_docs/version-4.1.x/deployment-concepts/invoke-appdeploytoolkit.mdx
+++ b/versioned_docs/version-4.1.x/deployment-concepts/invoke-appdeploytoolkit.mdx
@@ -42,18 +42,18 @@ These are the first thing to edit in your deployment script and are stored withi
 | `AppProcessesToClose` | `@(@{ Name = 'winword'; Description = 'Microsoft Word' })` | **New in v4.1**. Processes that should be closed before install / uninstall / repair. |
 | `RequireAdmin`        | `$true`                                                    | **New in v4.1**. Whether the script requires administrative privileges                |
 
-:::warning Breaking Changes in v4.1
+:::warning[Breaking Changes in v4.1]
 If you are upgrading from v4.0 or earlier, you must move any `RequireAdmin` setting from your config file to the session object in your deployment script, and use `AppProcessesToClose` instead of specifying the processes directly on the `-CloseProcesses` parameter of `Show-ADTInstallationWelcome`.
 :::
 
-:::info New in v4.1: RequireAdmin
+:::info[New in v4.1: RequireAdmin]
 PSADT v4.1 contains a new variable `RequireAdmin` that allows you to check for administrative rights on a per-application basis without needing to modify the PSADT configuration file.
 
 - `RequireAdmin = $true`, will fail the deployment if admin rights are not available.
 - `RequireAdmin = $false`, will run in the users context without requiring administrative rights.
 :::
 
-:::info New in v4.1: AppProcessesToClose
+:::info[New in v4.1: AppProcessesToClose]
 PSADT v4.1 contains a new variable `AppProcessesToClose` that allows you to specify processes to be closed before the installation, uninstallation, or repair phases. This replaces the previous method of using the -CloseApps parameter on `Show-InstallationWelcome`
 
 - `AppProcessesToClose = <populated>`, will automatically close the specified processes before proceeding with the deployment.

--- a/versioned_docs/version-4.1.x/deployment-concepts/invoke-appdeploytoolkit.mdx
+++ b/versioned_docs/version-4.1.x/deployment-concepts/invoke-appdeploytoolkit.mdx
@@ -51,12 +51,12 @@ If you are upgrading from v4.0 or earlier, you must move any `RequireAdmin` sett
 :::
 
 :::info[New in v4.1: RequireAdmin]
-PSADT v4.1 contains a new variable `RequireAdmin` that allows you to check for administrative rights on a per-application basis without needing to modify the PSADT configuration file.
+PSADT v4.1 contains a new variable `RequireAdmin` that allows you to check for administrative privileges on a per-application basis without needing to modify the PSADT configuration file.
 
-- `RequireAdmin = $true`, will fail the deployment if admin rights are not available.
-- `RequireAdmin = $false`, will not check for admin rights.
+- `RequireAdmin = $true`, will fail the deployment if administrative privileges are not available.
+- `RequireAdmin = $false`, will not check for administrative privileges.
 
-Note that `Invoke-AppDeployToolkit.exe` no longer checks this value to figure out if it needs to relaunch itself elevated. If your deployment requires admin rights, you must ensure that the launcher is run elevated.
+Note that `Invoke-AppDeployToolkit.exe` no longer checks this value to figure out if it needs to relaunch itself elevated. If your deployment requires administrative privileges, you must ensure that the launcher is run elevated.
 :::
 
 :::info[New in v4.1: AppProcessesToClose]

--- a/versioned_docs/version-4.1.x/deployment-concepts/invoke-appdeploytoolkit.mdx
+++ b/versioned_docs/version-4.1.x/deployment-concepts/invoke-appdeploytoolkit.mdx
@@ -42,6 +42,10 @@ These are the first thing to edit in your deployment script and are stored withi
 | `AppProcessesToClose` | `@(@{ Name = 'winword'; Description = 'Microsoft Word' })` | **New in v4.1**. Processes that should be closed before install / uninstall / repair. |
 | `RequireAdmin`        | `$true`                                                    | **New in v4.1**. Whether the script requires administrative privileges                |
 
+:::warning[PSAppDeployToolkit variables]
+If trying to use a PSAppDeployToolkit variables such as $envProgramFiles in this section, it will not work because the module has typically not been imported and initialized this early on in the script.
+:::
+
 :::warning[Breaking Changes in v4.1]
 If you are upgrading from v4.0 or earlier, you must move any `RequireAdmin` setting from your config file to the session object in your deployment script, and use `AppProcessesToClose` instead of specifying the processes directly on the `-CloseProcesses` parameter of `Show-ADTInstallationWelcome`.
 :::

--- a/versioned_docs/version-4.1.x/deployment-concepts/invoke-appdeploytoolkit.mdx
+++ b/versioned_docs/version-4.1.x/deployment-concepts/invoke-appdeploytoolkit.mdx
@@ -56,7 +56,7 @@ PSADT v4.1 contains a new variable `RequireAdmin` that allows you to check for a
 - `RequireAdmin = $true`, will fail the deployment if admin rights are not available.
 - `RequireAdmin = $false`, will not check for admin rights.
 
-Note that Invoke-AppDeployToolkit.exe no longer checks this value to figure out if it needs to relaunch itself elevated. If your deployment requires admin rights, you must ensure that the launcher is run elevated.
+Note that `Invoke-AppDeployToolkit.exe` no longer checks this value to figure out if it needs to relaunch itself elevated. If your deployment requires admin rights, you must ensure that the launcher is run elevated.
 :::
 
 :::info[New in v4.1: AppProcessesToClose]

--- a/versioned_docs/version-4.1.x/deployment-concepts/invoke-appdeploytoolkit.mdx
+++ b/versioned_docs/version-4.1.x/deployment-concepts/invoke-appdeploytoolkit.mdx
@@ -54,7 +54,9 @@ If you are upgrading from v4.0 or earlier, you must move any `RequireAdmin` sett
 PSADT v4.1 contains a new variable `RequireAdmin` that allows you to check for administrative rights on a per-application basis without needing to modify the PSADT configuration file.
 
 - `RequireAdmin = $true`, will fail the deployment if admin rights are not available.
-- `RequireAdmin = $false`, will run in the users context without requiring administrative rights.
+- `RequireAdmin = $false`, will not check for admin rights.
+
+Note that Invoke-AppDeployToolkit.exe no longer checks this value to figure out if it needs to relaunch itself elevated. If your deployment requires admin rights, you must ensure that the launcher is run elevated.
 :::
 
 :::info[New in v4.1: AppProcessesToClose]

--- a/versioned_docs/version-4.1.x/getting-started/faq.mdx
+++ b/versioned_docs/version-4.1.x/getting-started/faq.mdx
@@ -111,7 +111,7 @@ tags:
 <details>
   <summary>Can I use PSAppDeployToolkit to install user-context apps?</summary>
 
-  Yes. Ensure `RequireAdmin = $false` is configured within the `$adtSession` properties in Invoke-AppDeployToolkit.ps1. As of 4.1, the `RequireAdmin` is no longer to be found in Config.psd1.
+  Yes. Ensure `RequireAdmin = $false` is configured within the `$adtSession` properties in `Invoke-AppDeployToolkit.ps1`. As of 4.1, the `RequireAdmin` is no longer to be found in Config.psd1.
 </details>
 
 <details>

--- a/versioned_docs/version-4.1.x/getting-started/release-notes.mdx
+++ b/versioned_docs/version-4.1.x/getting-started/release-notes.mdx
@@ -139,7 +139,7 @@ This release strengthens Windows Installer (.msi) and Patch (.msp) deployment re
 - Set default parameter set for `Start-ADTMspProcess`.
 - Changed `Start-ADTMsiProcessAsUser` to ensure it uses a user-writeable log location.
 - Fixed bad parameter set grouping for `Start-ADTProcess` family of functions.
-- Fixed issue where `Set-ADTItemPermissions` always needed admin rights to change inheritance options
+- Fixed issue where `Set-ADTItemPermissions` always needed administrative privileges to change inheritance options
 - Fixed issue where `Set-ADTActiveSetup` `-PurgeActiveSetupKey` would only clean up keys for the active user.
 - Fixed `StdOut`/`StdErr`/`Interleaved` printing within `Start-ADTProcess`.
 - Changed `Start-ADTProcessAsUser` to allow operating with any valid user, such as disconnected RDP users.

--- a/versioned_docs/version-4.1.x/getting-started/upgrade-guidance-4x-to-v41.mdx
+++ b/versioned_docs/version-4.1.x/getting-started/upgrade-guidance-4x-to-v41.mdx
@@ -20,7 +20,7 @@ tags:
 - `OOBEDetection` and `SessionDetection` are no longer set in Config.psd1. They can be set per-deployment by adding the `NoOOBEDetection` and `NoSessionDetection` options to the session properties if required.
 - `AppProcessesToClose` is a new session property that allows you to define processes to close during Install/Uninstall/Repair in one place instead of specifying the processes directly on the `-CloseProcesses` parameter of `Show-ADTInstallationWelcome`.
 - `RequireAdmin` is no longer set in Config.psd1. It must be set per-deployment in the session properties.
-- Invoke-AppDeployToolkit.exe no longer requests elevation if RequireAdmin is set; you must elevate this yourself.
+- `Invoke-AppDeployToolkit.exe` no longer requests elevation if RequireAdmin is set; you must elevate this yourself.
 - Several config options have been removed or had their default values changed. See below for details.
 - Deprecated functions and parameters are scheduled for removal in 4.2.0. Update your scripts accordingly.
 

--- a/versioned_docs/version-4.1.x/getting-started/upgrade-guidance-4x-to-v41.mdx
+++ b/versioned_docs/version-4.1.x/getting-started/upgrade-guidance-4x-to-v41.mdx
@@ -20,6 +20,7 @@ tags:
 - `OOBEDetection` and `SessionDetection` are no longer set in Config.psd1. They can be set per-deployment by adding the `NoOOBEDetection` and `NoSessionDetection` options to the session properties if required.
 - `AppProcessesToClose` is a new session property that allows you to define processes to close during Install/Uninstall/Repair in one place instead of specifying the processes directly on the `-CloseProcesses` parameter of `Show-ADTInstallationWelcome`.
 - `RequireAdmin` is no longer set in Config.psd1. It must be set per-deployment in the session properties.
+- Invoke-AppDeployToolkit.exe no longer requests elevation if RequireAdmin is set; you must elevate this yourself.
 - Several config options have been removed or had their default values changed. See below for details.
 - Deprecated functions and parameters are scheduled for removal in 4.2.0. Update your scripts accordingly.
 

--- a/versioned_docs/version-4.1.x/introduction.mdx
+++ b/versioned_docs/version-4.1.x/introduction.mdx
@@ -32,7 +32,7 @@ PSAppDeployToolkit is open-source software and provided free for anyone to use. 
 - [Functions Reference](./category/functions)
   - A reference for all the functions provided by PSAppDeployToolkit, including parameters and examples of how to use them.
 
-:::info Enterpise Support
+:::info[Enterprise Support]
 
 We recognize that some enterprises face adoption challenges due to audit requirements for vendor support. Patch My PC are stewards of the PSADT Project and, as experts in open-source deployment, are uniquely positioned to offer both deep technical knowledge and enterprise-level support - allowing customers to fully benefit from open-source tools without compromise. [Learn more about Patch My PC's support for PSADT](https://patchmypc.com/support/psappdeploytoolkit-support).
 :::

--- a/versioned_docs/version-4.1.x/reference/config-settings.mdx
+++ b/versioned_docs/version-4.1.x/reference/config-settings.mdx
@@ -50,15 +50,15 @@ In PSADT v4.1, we've introduced **Group Policy ADMX templates** for centralized 
 | `Toolkit.LogMaxHistory`             | Sets the maximum history for logs.                                                                                                                                                               |
 | `Toolkit.LogMaxSize`                | Defines the maximum size for logs.                                                                                                                                                               |
 | `Toolkit.LogPath`                   | Specifies the path where logs are stored.                                                                                                                                                        |
-| `Toolkit.LogPathNoAdminRights`      | Specifies the log path when no admin rights are available.                                                                                                                                       |
+| `Toolkit.LogPathNoAdminRights`      | Specifies the log path when no administrative privileges are available.                                                                                                                                       |
 | `Toolkit.LogStyle`                  | Sets the style for logging.                                                                                                                                                                      |
 | `Toolkit.LogToHierarchy`            | Log to a hierarchical structure of AppVendor\AppName\AppVersion.                                                                                                                                 |
 | `Toolkit.LogToSubfolder`            | Log to a subfolder based on InstallName.                                                                                                                                                         |
 | `Toolkit.LogWriteToHost`            | Determines if logs should be written to the host.                                                                                                                                                |
 | `Toolkit.RegPath`                   | Specifies the registry path for the toolkit.                                                                                                                                                     |
-| `Toolkit.RegPathNoAdminRights`      | Specifies the registry path when no admin rights are available.                                                                                                                                  |
+| `Toolkit.RegPathNoAdminRights`      | Specifies the registry path when no administrative privileges are available.                                                                                                                                  |
 | `Toolkit.TempPath`                  | Specifies the temporary path for the toolkit.                                                                                                                                                    |
-| `Toolkit.TempPathNoAdminRights`     | Specifies the temporary path when no admin rights are available.                                                                                                                                 |
+| `Toolkit.TempPathNoAdminRights`     | Specifies the temporary path when no administrative privileges are available.                                                                                                                                 |
 
 #### Windows Installer (MSI) Execution Settings
 
@@ -67,7 +67,7 @@ In PSADT v4.1, we've introduced **Group Policy ADMX templates** for centralized 
 | `MSI.InstallParams`        | Defines the installation parameters for MSI. **Default changed to `/qn REBOOT=ReallySuppress`**                         |
 | `MSI.LoggingOptions`       | Specifies the logging options for MSI.                                                                                  |
 | `MSI.LogPath`              | Specifies the log path for MSI. **Now uses Toolkit.LogPath when empty**                                                 |
-| `MSI.LogPathNoAdminRights` | Specifies the log path for MSI when no admin rights are available. **Now uses Toolkit.LogPathNoAdminRights when empty** |
+| `MSI.LogPathNoAdminRights` | Specifies the log path for MSI when no administrative privileges are available. **Now uses Toolkit.LogPathNoAdminRights when empty** |
 | `MSI.MutexWaitTime`        | Sets the mutex wait time for MSI.                                                                                       |
 | `MSI.SilentParams`         | Defines the silent parameters for MSI.                                                                                  |
 | `MSI.UninstallParams`      | Defines the uninstall parameters for MSI.                                                                               |

--- a/versioned_docs/version-4.1.x/reference/config-settings.mdx
+++ b/versioned_docs/version-4.1.x/reference/config-settings.mdx
@@ -32,7 +32,7 @@ In PSADT v4.1, we've introduced **Group Policy ADMX templates** for centralized 
 | `Assets.Logo`     | Specifies the logo asset.         |
 | `Assets.LogoDark` | Path to the dark mode logo image. |
 
-:::info Dark Mode Support
+:::info[Dark Mode Support]
 `Assets.LogoDark` enables different logos for light and dark themes in the modern Fluent UI framework.
 :::
 
@@ -63,7 +63,7 @@ In PSADT v4.1, we've introduced **Group Policy ADMX templates** for centralized 
 | `Toolkit.TempPath`                  | Specifies the temporary path for the toolkit.                                                                                                                                                    |
 | `Toolkit.TempPathNoAdminRights`     | Specifies the temporary path when no admin rights are available.                                                                                                                                 |
 
-:::info Automatic Silent Switching
+:::info[Automatic Silent Switching]
 When `Toolkit.ProcessDetection` is enabled and no processes from `AppProcessesToClose` are running, deployments automatically switch to Silent mode for optimal user experience.
 :::
 
@@ -94,6 +94,6 @@ When `Toolkit.ProcessDetection` is enabled and no processes from `AppProcessesTo
 | `UI.PromptToSaveTimeout`          | Controls how long the user has to respond before a prompt closes.         |
 | `UI.RestartPromptPersistInterval` | Sets the interval for restart prompt persistence.                         |
 
-:::info Custom Branding
+:::info[Custom Branding]
 Use `UI.FluentAccentColor` to match your organization's branding in modern Fluent UI dialogs. Supports standard color names and hex values.
 :::

--- a/versioned_docs/version-4.1.x/reference/config-settings.mdx
+++ b/versioned_docs/version-4.1.x/reference/config-settings.mdx
@@ -55,17 +55,10 @@ In PSADT v4.1, we've introduced **Group Policy ADMX templates** for centralized 
 | `Toolkit.LogToHierarchy`            | Log to a hierarchical structure of AppVendor\AppName\AppVersion.                                                                                                                                 |
 | `Toolkit.LogToSubfolder`            | Log to a subfolder based on InstallName.                                                                                                                                                         |
 | `Toolkit.LogWriteToHost`            | Determines if logs should be written to the host.                                                                                                                                                |
-| `Toolkit.OobeDetection`             | Detects Out-of-Box Experience (OOBE) state. If enabled, the toolkit will check if the device has completed OOBE (including User ESP phase as of 4.1) and may switch DeployMode to Silent if not. |
-| `Toolkit.ProcessDetection`          | Auto-change DeployMode if there are no processes to close.                                                                                                                                       |
 | `Toolkit.RegPath`                   | Specifies the registry path for the toolkit.                                                                                                                                                     |
 | `Toolkit.RegPathNoAdminRights`      | Specifies the registry path when no admin rights are available.                                                                                                                                  |
-| `Toolkit.SessionDetection`          | Detects user session state. If enabled, the toolkit will check for an active user session and may switch DeployMode to Silent if none is found.                                                  |
 | `Toolkit.TempPath`                  | Specifies the temporary path for the toolkit.                                                                                                                                                    |
 | `Toolkit.TempPathNoAdminRights`     | Specifies the temporary path when no admin rights are available.                                                                                                                                 |
-
-:::info[Automatic Silent Switching]
-When `Toolkit.ProcessDetection` is enabled and no processes from `AppProcessesToClose` are running, deployments automatically switch to Silent mode for optimal user experience.
-:::
 
 #### Windows Installer (MSI) Execution Settings
 

--- a/versioned_docs/version-4.1.x/reference/exit-codes.mdx
+++ b/versioned_docs/version-4.1.x/reference/exit-codes.mdx
@@ -16,7 +16,7 @@ PSAppDeployToolkit uses pre-defined exit codes to indicate whether a deployment 
 
 | Exit Code     | Description                                                                                                                       |
 | :------------ | :-------------------------------------------------------------------------------------------------------------------------------- |
-| 60000 - 68999 | Reserved for built-in exit codes in _Invoke-AppDeployToolkit.ps1_, _Invoke-AppDeployToolkit.exe_, and _AppDeployToolkitMain.ps1_. |
+| 60000 - 68999 | Reserved for built-in exit codes in `Invoke-AppDeployToolkit.ps1`, `Invoke-AppDeployToolkit.exe`, and `AppDeployToolkitMain.ps1`. |
 | 60001         | An error occurred in `Invoke-AppDeployToolkit.ps1`. Check your script syntax use.                                                 |
 | 60008         | Failure when importing the module or opening a new session.                                                                       |
 | 60010         | `Invoke-AppDeployToolkit.exe` failed before PowerShell.exe process could be launched.                                             |

--- a/versioned_docs/version-4.1.x/reference/variables.mdx
+++ b/versioned_docs/version-4.1.x/reference/variables.mdx
@@ -12,7 +12,7 @@ tags:
 
 ## Variables
 
-When you open an ADTSession (automatically handled in Invoke-AppDeployToolkit.ps1), several useful variables are created. These include hardware information, system and user paths, and Active Directory domain details, among others.
+When you open an ADTSession (automatically handled in `Invoke-AppDeployToolkit.ps1`), several useful variables are created. These include hardware information, system and user paths, and Active Directory domain details, among others.
 
 These variables can also be instantiated without opening a session by calling the [Export-ADTEnvironmentTableToSessionState](../reference/functions/Export-ADTEnvironmentTableToSessionState.mdx) command.
 

--- a/versioned_docs/version-4.1.x/reference/variables.mdx
+++ b/versioned_docs/version-4.1.x/reference/variables.mdx
@@ -102,7 +102,7 @@ Variables specific to a particular deployment, such as `$appName` and `$appVersi
 | Variable                | Description                                                                                                 |
 | :---------------------- | :---------------------------------------------------------------------------------------------------------- |
 | `$envOS`                | Object that contains details about the operating system                                                     |
-| `$envOSArchitecture`    | Represents the OS architecture (e.g. 32-Bit/64-Bit)                                                         |
+| `$envOSArchitecture`    | Represents the OS architecture (e.g. X86/X64/Arm64)                                                         |
 | `$envOSName`            | Name of the operating system (e.g. Microsoft Windows 8.1 Pro)                                               |
 | `$envOSProductType`     | OS product type represented as an integer (e.g. 1/2/3)                                                      |
 | `$envOSProductTypeName` | OS product type name (e.g. Server/Domain Controller/Workstation/Unknown)                                    |

--- a/versioned_docs/version-4.1.x/usage/how-to-deploy.mdx
+++ b/versioned_docs/version-4.1.x/usage/how-to-deploy.mdx
@@ -17,20 +17,21 @@ There are two ways to launch the PSAppDeployToolkit for deployment of applicatio
 `%SystemRoot%\System32\WindowsPowerShell\v1.0\PowerShell.exe -ExecutionPolicy Bypass -NoProfile -File Invoke-AppDeployToolkit.ps1`
 - Run `Invoke-AppDeployToolkit.exe` to launch `Invoke-AppDeployToolkit.ps1` in a hidden PowerShell window.
 
-:::info
+:::info[Elevation]
+If your script uses `RequireAdmin = $true`, you will need to run it as admin; the launcher will not prompt for elevation by itself.
+:::
+
+:::info[ServiceUI]
 Additionally, as of v4.1.0:
 
 - If deploying via **Intune**, there is no longer any reqirement to use `ServiceUI.exe` workarounds to display the UI.
 - If deploying via **Configuration Manager**, the **'Allow users to view and interact with the program installation'** option is no longer required to display the UI.
 - Invoke-ServiceUI.ps1 has been removed from the toolkit as it is no longer required.
-
 :::
 
 :::warning
-
 - If you want to deploy an installer interactively, you can include ServiceUI.exe in your package and use that to trigger your installer.
 - However, this is a security risk since any file dialogs or hyperlinks can be abused by the user to gain access as local system.
-
 :::
 
 ### Available parameters

--- a/versioned_docs/version-4.1.x/usage/how-to-deploy.mdx
+++ b/versioned_docs/version-4.1.x/usage/how-to-deploy.mdx
@@ -46,15 +46,15 @@ The following parameters are accepted by `Invoke-AppDeployToolkit.ps1` and `Invo
 | `-TerminalServerMode`                                                 |                                                            | Changes to user install mode for RDS/Citrix servers.                                                                           |
 | `-DisableLogging`                                                     |                                                            | Disables logging to file.                                                                                                      |
 
-In addition, Invoke-AppDeployToolkit.exe supports the following parameters:
+In addition, `Invoke-AppDeployToolkit.exe` supports the following parameters:
 
 | Parameter | Values | Description                                                                                                  |
 | --------- | ------ | ------------------------------------------------------------------------------------------------------------ |
 | `/Debug`  |        | Launches the script in a visible window displaying live logging output on-screen.                            |
 | `/32`     |        | Launches the script using PowerShell x86. This is useful for compatibility with x86 libraries or components. |
 | `/Core`   |        | Launches the script using PowerShell Core (pwsh.exe).                                                        |
-| `-File`   | *.ps1  | Specify a custom script file to run instead of the default Invoke-AppDeployToolkit.ps1.                      |
-| `*.ps1`   |        | Specify a custom script file to run instead of the default Invoke-AppDeployToolkit.ps1.                      |
+| `-File`   | *.ps1  | Specify a custom script file to run instead of the default `Invoke-AppDeployToolkit.ps1`.                      |
+| `*.ps1`   |        | Specify a custom script file to run instead of the default `Invoke-AppDeployToolkit.ps1`.                      |
 
 ### Examples
 


### PR DESCRIPTION
- Fix syntax on Docusaurus .mdx admonition titles. Fixes #378
- Update $envOSArchitecture values on Variables page - fixes #276
- Update ADMX references - fixes #201
- Add callout that PSADT variables should not be used in adtSession hashtable definition as they do not yet exist at this point in the script - fixes #187
- Add info to clarify that Invoke-AppDeployToolkit.exe no longer auto elevates - fixes #144